### PR TITLE
make secondary_ fields type "nested" because they are arrays of objec…

### DIFF
--- a/mappings/DocumentMapping.json
+++ b/mappings/DocumentMapping.json
@@ -144,6 +144,7 @@
           }
         },
         "secondary_categories": {
+          "type": "nested",
           "properties": {
             "id": {
               "type": "keyword"
@@ -154,6 +155,7 @@
           }
         },
         "secondary_archives": {
+          "type": "nested",
           "properties": {
             "id": {
               "type": "keyword"
@@ -164,6 +166,7 @@
           }
         },
         "secondary_groups": {
+          "type": "nested",
           "properties": {
             "id": {
               "type": "keyword"


### PR DESCRIPTION
…ts [ARXIVNG-185]