### PR TITLE
Adding size and start to OpenAPI parameters list ARXIVNG-1895 ARXIVNG-1896

### DIFF
--- a/schema/search.yaml
+++ b/schema/search.yaml
@@ -399,6 +399,26 @@ paths:
               - submitted_date
               - announced_date_first
           example: submitted_date_first
+        
+        - name: start
+          in: query
+          description: |
+            Defines the index of the first returned result, using 0-based indexing.
+          required: false
+          schema:
+            type: integer
+          example: 0
+
+        - name: size
+          in: query
+          description: |
+            The number of results returned by the query. Used in conjunction with "start" for 
+            pagination. Size is limited to 30000, in slices of 2000.
+          required: false
+          schema:
+            type: integer
+          example: 10
+        
 
       responses:
         '200':

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -196,7 +196,7 @@ class ClassificationList(list):
 class Query:
     """Represents a search query originating from the UI or API."""
 
-    MAXIMUM_size = 500
+    MAXIMUM_size = 2000
     """The maximum number of records that can be retrieved."""
 
     SUPPORTED_FIELDS = [


### PR DESCRIPTION
Fairly self-explanatory. Adding size and start to OpanAPI parameters list.

Also adjusts the `Query.MAXIMUM_size` to 2000 to match old export.arxiv.org settings.