### PR TITLE
Feature/#266 fix ordering in classic api

### DIFF
--- a/bulk_index.py
+++ b/bulk_index.py
@@ -1,21 +1,19 @@
 """Use this to populate a search index for testing."""
 
-import json
 import os
+import json
 import tempfile
-import click
-from itertools import islice, groupby
+import operator
 from typing import List
-import re
-from search.factory import create_ui_web_app
-from search.agent import (
-    MetadataRecordProcessor,
-    DocumentFailed,
-    IndexingFailed,
-)
-from search.domain import asdict, DocMeta, Document
-from search.services import metadata, index
+from itertools import groupby
+
+import click
+
 from search.process import transform
+from search.domain import asdict, DocMeta
+from search.services import metadata, index
+from search.factory import create_ui_web_app
+
 
 app = create_ui_web_app()
 
@@ -87,7 +85,7 @@ def populate(
                     except metadata.ConnectionFailed:  # Try again.
                         new_meta = metadata.bulk_retrieve(chunk)
                     # Add metadata to the cache.
-                    key = lambda dm: dm.paper_id
+                    key = operator.attrgetter("paper_id")
                     new_meta_srt = sorted(new_meta, key=key)
                     for paper_id, grp in groupby(new_meta_srt, key):
                         to_cache(cache_dir, paper_id, [dm for dm in grp])

--- a/search/consts.py
+++ b/search/consts.py
@@ -1,0 +1,6 @@
+# Sorting
+
+DEFAULT_SORT_ORDER = [
+    {"announced_date_first": {"order": "desc"}},
+    {"_doc": {"order": "asc"}},
+]

--- a/search/consts.py
+++ b/search/consts.py
@@ -1,6 +1,13 @@
+from pytz import timezone
+
 # Sorting
 
 DEFAULT_SORT_ORDER = [
     {"announced_date_first": {"order": "desc"}},
     {"_doc": {"order": "asc"}},
 ]
+
+
+# Timezones
+
+EASTERN = timezone("US/Eastern")

--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -8,7 +8,6 @@ parameters, and produce informative error messages for the user.
 """
 
 import re
-from pytz import timezone
 from typing import Tuple, List, Dict, Any, Optional
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
@@ -30,6 +29,7 @@ from search.domain import (
     ClassificationList,
     Query,
 )
+from search import consts
 from search.controllers.advanced import forms
 from search.controllers.util import paginate, catch_underscore_syntax
 
@@ -40,7 +40,6 @@ logger = logging.getLogger(__name__)
 Response = Tuple[Dict[str, Any], int, Dict[str, Any]]
 
 
-EASTERN = timezone("US/Eastern")
 TERM_FIELD_PTN = re.compile(r"terms-([0-9])+-term")
 
 
@@ -272,7 +271,7 @@ def _update_query_with_dates(
                 hour=0,
                 minute=0,
                 second=0,
-                tzinfo=EASTERN,
+                tzinfo=consts.EASTERN,
             )
         )
     elif filter_by == "specific_year":
@@ -284,7 +283,7 @@ def _update_query_with_dates(
                 hour=0,
                 minute=0,
                 second=0,
-                tzinfo=EASTERN,
+                tzinfo=consts.EASTERN,
             ),
             end_date=datetime(
                 year=date_data["year"].year + 1,
@@ -293,17 +292,21 @@ def _update_query_with_dates(
                 hour=0,
                 minute=0,
                 second=0,
-                tzinfo=EASTERN,
+                tzinfo=consts.EASTERN,
             ),
         )
     elif filter_by == "date_range":
         if date_data["from_date"]:
             date_data["from_date"] = datetime.combine(  # type: ignore
-                date_data["from_date"], datetime.min.time(), tzinfo=EASTERN
+                date_data["from_date"],
+                datetime.min.time(),
+                tzinfo=consts.EASTERN,
             )
         if date_data["to_date"]:
             date_data["to_date"] = datetime.combine(  # type: ignore
-                date_data["to_date"], datetime.min.time(), tzinfo=EASTERN
+                date_data["to_date"],
+                datetime.min.time(),
+                tzinfo=consts.EASTERN,
             )
 
         q.date_range = DateRange(  # type: ignore

--- a/search/controllers/api/__init__.py
+++ b/search/controllers/api/__init__.py
@@ -1,18 +1,18 @@
 """Controller for search API requests."""
 
+import pytz
 from collections import defaultdict
 from typing import Tuple, Dict, Any, Optional, List, Union
-from mypy_extensions import TypedDict
 
 import dateutil.parser
-import pytz
-from pytz import timezone
+from mypy_extensions import TypedDict
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import BadRequest, NotFound
 
 from arxiv import status, taxonomy
 from arxiv.base import logging
 
+from search import consts
 from search.services import index
 from search.controllers.util import paginate
 from search.domain import (
@@ -28,7 +28,7 @@ from search.domain import (
 
 
 logger = logging.getLogger(__name__)
-EASTERN = timezone("US/Eastern")
+
 
 SearchResponseData = TypedDict(
     "SearchResponseData",
@@ -191,7 +191,7 @@ def _get_date_params(
             dt = dateutil.parser.parse(value[0])
             if not dt.tzinfo:
                 dt = pytz.utc.localize(dt)
-            dt = dt.replace(tzinfo=EASTERN)
+            dt = dt.replace(tzinfo=consts.EASTERN)
         except ValueError:
             raise BadRequest(f"Invalid datetime in {field}")
         date_params[field] = dt

--- a/search/controllers/api/tests/tests_api_search.py
+++ b/search/controllers/api/tests/tests_api_search.py
@@ -1,14 +1,13 @@
 """Tests for advanced search controller, :mod:`search.controllers.advanced`."""
 
+from http import HTTPStatus
 from unittest import TestCase, mock
 from werkzeug import MultiDict
 from werkzeug.exceptions import BadRequest
 
-from arxiv import status
-
-from search.domain import DateRange, Classification
 from search.controllers import api
 from search.domain import api as api_domain
+from search.domain import DateRange, Classification
 
 
 class TestAPISearch(TestCase):
@@ -20,7 +19,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         self.assertIn("results", data, "Results are returned")
         self.assertIn("query", data, "Query object is returned")
         expected_fields = (
@@ -39,7 +38,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"query": 'au:copernicus AND ti:"dark matter"'})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         self.assertIn("results", data, "Results are returned")
         self.assertIn("query", data, "Query object is returned")
         expected_fields = (
@@ -59,7 +58,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"include": extra_fields})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         self.assertIn("results", data, "Results are returned")
         self.assertIn("query", data, "Query object is returned")
         expected_fields = api_domain.get_required_fields() + extra_fields
@@ -76,7 +75,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"primary_classification": group})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertEqual(len(query.primary_classification), 1)
         self.assertEqual(
@@ -91,7 +90,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"primary_classification": archive})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertEqual(len(query.primary_classification), 1)
         self.assertEqual(
@@ -106,7 +105,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"primary_classification": archive})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertEqual(len(query.primary_classification), 2)
         self.assertEqual(
@@ -126,7 +125,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"primary_classification": category})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertEqual(len(query.primary_classification), 1)
         self.assertEqual(
@@ -147,7 +146,7 @@ class TestAPISearch(TestCase):
         params = MultiDict({"start_date": "1999-01-02"})
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertIsNotNone(query.date_range)
         self.assertEqual(query.date_range.start_date.year, 1999)
@@ -167,7 +166,7 @@ class TestAPISearch(TestCase):
         )
         data, code, headers = api.search(params)
 
-        self.assertEqual(code, status.HTTP_200_OK, "Returns 200 OK")
+        self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
         query = mock_index.search.call_args[0][0]
         self.assertIsNotNone(query.date_range)
         self.assertEqual(query.date_range.end_date.year, 1999)

--- a/search/controllers/classic_api/__init__.py
+++ b/search/controllers/classic_api/__init__.py
@@ -116,12 +116,34 @@ def query(
             link="http://arxiv.org/api/errors#start_must_be_non-negative",
         )
 
+    # sort by and sort order
+    value = params.get("sortBy", ClassicAPIQuery.SortBy.relevance)
+    try:
+        sort_by = ClassicAPIQuery.SortBy(value)
+    except ValueError:
+        raise ValidationError(
+            message=f"sortBy must be in: {', '.join(ClassicAPIQuery.SortBy)}",
+            link="https://arxiv.org/help/api/user-manual#sort",
+        )
+    value = params.get("sortOrder", ClassicAPIQuery.SortOrder.descending)
+    try:
+        sort_order = ClassicAPIQuery.SortOrder(value)
+    except ValueError:
+        raise ValidationError(
+            message=(
+                f"sortOrder must be in: {', '.join(ClassicAPIQuery.SortOrder)}"
+            ),
+            link="https://arxiv.org/help/api/user-manual#sort",
+        )
+
     try:
         query = ClassicAPIQuery(
             search_query=search_query,
             id_list=id_list,
             size=max_results,
             page_start=start,
+            sort_by=sort_by,
+            sort_order=sort_order,
         )
     except ValueError:
         raise BadRequest(

--- a/search/controllers/classic_api/__init__.py
+++ b/search/controllers/classic_api/__init__.py
@@ -1,6 +1,5 @@
 """Controller for classic arXiv API requests."""
 
-from pytz import timezone
 from http import HTTPStatus
 from typing import Tuple, Dict, Any
 
@@ -22,7 +21,6 @@ from search.domain import (
 )
 
 logger = logging.getLogger(__name__)
-EASTERN = timezone("US/Eastern")
 
 
 def query(

--- a/search/controllers/classic_api/__init__.py
+++ b/search/controllers/classic_api/__init__.py
@@ -13,6 +13,9 @@ from arxiv.identifier import parse_arxiv_id
 from search.services import index
 from search.errors import ValidationError
 from search.domain import (
+    SortDirection,
+    SortBy,
+    SortOrder,
     DocumentSet,
     ClassicAPIQuery,
     ClassicSearchResponseData,
@@ -115,33 +118,30 @@ def query(
         )
 
     # sort by and sort order
-    value = params.get("sortBy", ClassicAPIQuery.SortBy.relevance)
+    value = params.get("sortBy", SortBy.relevance)
     try:
-        sort_by = ClassicAPIQuery.SortBy(value)
+        sort_by = SortBy(value)
     except ValueError:
         raise ValidationError(
-            message=f"sortBy must be in: {', '.join(ClassicAPIQuery.SortBy)}",
+            message=f"sortBy must be in: {', '.join(SortBy)}",
             link="https://arxiv.org/help/api/user-manual#sort",
         )
-    value = params.get("sortOrder", ClassicAPIQuery.SortOrder.descending)
+    value = params.get("sortOrder", SortDirection.descending)
     try:
-        sort_order = ClassicAPIQuery.SortOrder(value)
+        sort_direction = SortDirection(value)
     except ValueError:
         raise ValidationError(
-            message=(
-                f"sortOrder must be in: {', '.join(ClassicAPIQuery.SortOrder)}"
-            ),
+            message=f"sortOrder must be in: {', '.join(SortDirection)}",
             link="https://arxiv.org/help/api/user-manual#sort",
         )
 
     try:
         classic_query = ClassicAPIQuery(
+            order=SortOrder(by=sort_by, direction=sort_direction),
             search_query=search_query,
             id_list=id_list,
             size=max_results,
             page_start=start,
-            sort_by=sort_by,
-            sort_order=sort_order,
         )
     except ValueError:
         raise BadRequest(

--- a/search/controllers/classic_api/tests/test_classic_search.py
+++ b/search/controllers/classic_api/tests/test_classic_search.py
@@ -4,6 +4,8 @@ from unittest import TestCase, mock
 from werkzeug import MultiDict
 from werkzeug.exceptions import BadRequest
 
+from search import domain
+from search.errors import ValidationError
 from search.controllers import classic_api
 
 
@@ -15,7 +17,7 @@ class TestClassicAPISearch(TestCase):
         """Request with no parameters."""
         params = MultiDict({})
         with self.assertRaises(BadRequest):
-            data, code, headers = classic_api.query(params)
+            _, _, _ = classic_api.query(params)
 
     @mock.patch(f"{classic_api.__name__}.index.SearchSession")
     def test_classic_query(self, mock_index):
@@ -24,8 +26,8 @@ class TestClassicAPISearch(TestCase):
 
         data, code, headers = classic_api.query(params)
         self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
-        self.assertIn("results", data, "Results are returned")
-        self.assertIn("query", data, "Query object is returned")
+        self.assertIsNotNone(data.results, "Results are returned")
+        self.assertIsNotNone(data.query, "Query object is returned")
 
     @mock.patch(f"{classic_api.__name__}.index.SearchSession")
     def test_classic_query_with_quotes(self, mock_index):
@@ -34,8 +36,8 @@ class TestClassicAPISearch(TestCase):
 
         data, code, headers = classic_api.query(params)
         self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
-        self.assertIn("results", data, "Results are returned")
-        self.assertIn("query", data, "Query object is returned")
+        self.assertIsNotNone(data.results, "Results are returned")
+        self.assertIsNotNone(data.query, "Query object is returned")
 
     @mock.patch(f"{classic_api.__name__}.index.SearchSession")
     def test_classic_id_list(self, mock_index):
@@ -44,5 +46,87 @@ class TestClassicAPISearch(TestCase):
 
         data, code, headers = classic_api.query(params)
         self.assertEqual(code, HTTPStatus.OK, "Returns 200 OK")
-        self.assertIn("results", data, "Results are returned")
-        self.assertIn("query", data, "Query object is returned")
+        self.assertIsNotNone(data.results, "Results are returned")
+        self.assertIsNotNone(data.query, "Query object is returned")
+
+    @mock.patch(f"{classic_api.__name__}.index.SearchSession")
+    def test_classic_start(self, mock_index):
+        # Default value
+        params = MultiDict({"search_query": "au:Copernicus"})
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.page_start, 0)
+        # Valid value
+        params = MultiDict({"search_query": "au:Copernicus", "start": "50"})
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.page_start, 50)
+        # Invalid value
+        params = MultiDict({"search_query": "au:Copernicus", "start": "-1"})
+        with self.assertRaises(ValidationError):
+            data, _, _ = classic_api.query(params)
+        params = MultiDict({"search_query": "au:Copernicus", "start": "foo"})
+        with self.assertRaises(ValidationError):
+            data, _, _ = classic_api.query(params)
+
+    @mock.patch(f"{classic_api.__name__}.index.SearchSession")
+    def test_classic_max_result(self, mock_index):
+        # Default value
+        params = MultiDict({"search_query": "au:Copernicus"})
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.size, 10)
+        # Valid value
+        params = MultiDict(
+            {"search_query": "au:Copernicus", "max_results": "50"}
+        )
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.size, 50)
+        # Invalid value
+        params = MultiDict(
+            {"search_query": "au:Copernicus", "max_results": "-1"}
+        )
+        with self.assertRaises(ValidationError):
+            _, _, _ = classic_api.query(params)
+        params = MultiDict(
+            {"search_query": "au:Copernicus", "max_results": "foo"}
+        )
+        with self.assertRaises(ValidationError):
+            _, _, _ = classic_api.query(params)
+
+    @mock.patch(f"{classic_api.__name__}.index.SearchSession")
+    def test_classic_sort_by(self, mock_index):
+        # Default value
+        params = MultiDict({"search_query": "au:Copernicus"})
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.sort_by, domain.SortBy.relevance)
+        # Valid value
+        for value in domain.SortBy:
+            params = MultiDict(
+                {"search_query": "au:Copernicus", "sortBy": f"{value}"}
+            )
+            data, _, _ = classic_api.query(params)
+            self.assertEqual(data.query.sort_by, value)
+
+        # Invalid value
+        params = MultiDict({"search_query": "au:Copernicus", "sortBy": "foo"})
+        with self.assertRaises(ValidationError):
+            data, _, _ = classic_api.query(params)
+
+    @mock.patch(f"{classic_api.__name__}.index.SearchSession")
+    def test_classic_sort_order(self, mock_index):
+        # Default value
+        params = MultiDict({"search_query": "au:Copernicus"})
+        data, _, _ = classic_api.query(params)
+        self.assertEqual(data.query.sort_order, domain.SortOrder.descending)
+        # Valid value
+        for value in domain.SortOrder:
+            params = MultiDict(
+                {"search_query": "au:Copernicus", "sortOrder": f"{value}"}
+            )
+            data, _, _ = classic_api.query(params)
+            self.assertEqual(data.query.sort_order, value)
+
+        # Invalid value
+        params = MultiDict(
+            {"search_query": "au:Copernicus", "sortOrder": "foo"}
+        )
+        with self.assertRaises(ValidationError):
+            data, _, _ = classic_api.query(params)

--- a/search/controllers/classic_api/tests/test_classic_search.py
+++ b/search/controllers/classic_api/tests/test_classic_search.py
@@ -96,14 +96,14 @@ class TestClassicAPISearch(TestCase):
         # Default value
         params = MultiDict({"search_query": "au:Copernicus"})
         data, _, _ = classic_api.query(params)
-        self.assertEqual(data.query.sort_by, domain.SortBy.relevance)
+        self.assertEqual(data.query.order.by, domain.SortBy.relevance)
         # Valid value
         for value in domain.SortBy:
             params = MultiDict(
                 {"search_query": "au:Copernicus", "sortBy": f"{value}"}
             )
             data, _, _ = classic_api.query(params)
-            self.assertEqual(data.query.sort_by, value)
+            self.assertEqual(data.query.order.by, value)
 
         # Invalid value
         params = MultiDict({"search_query": "au:Copernicus", "sortBy": "foo"})
@@ -115,14 +115,16 @@ class TestClassicAPISearch(TestCase):
         # Default value
         params = MultiDict({"search_query": "au:Copernicus"})
         data, _, _ = classic_api.query(params)
-        self.assertEqual(data.query.sort_order, domain.SortOrder.descending)
+        self.assertEqual(
+            data.query.order.direction, domain.SortDirection.descending
+        )
         # Valid value
-        for value in domain.SortOrder:
+        for value in domain.SortDirection:
             params = MultiDict(
                 {"search_query": "au:Copernicus", "sortOrder": f"{value}"}
             )
             data, _, _ = classic_api.query(params)
-            self.assertEqual(data.query.sort_order, value)
+            self.assertEqual(data.query.order.direction, value)
 
         # Invalid value
         params = MultiDict(

--- a/search/domain/__init__.py
+++ b/search/domain/__init__.py
@@ -20,8 +20,10 @@ __all__ = [
     "Field",
     "Term",
     "Phrase",
-    "SortOrder",
+    "Phrase",
+    "SortDirection",
     "SortBy",
+    "SortOrder",
     "Query",
     "SimpleQuery",
     # advanced
@@ -52,8 +54,9 @@ from search.domain.base import (
     Field,
     Term,
     Phrase,
-    SortOrder,
+    SortDirection,
     SortBy,
+    SortOrder,
     Query,
     SimpleQuery,
 )

--- a/search/domain/__init__.py
+++ b/search/domain/__init__.py
@@ -19,6 +19,8 @@ __all__ = [
     "Field",
     "Term",
     "Phrase",
+    "SortBy",
+    "SortOrder",
     "Query",
     "SimpleQuery",
     # advanced
@@ -47,6 +49,8 @@ from search.domain.base import (
     Field,
     Term,
     Phrase,
+    SortBy,
+    SortOrder,
     Query,
     SimpleQuery,
 )

--- a/search/domain/__init__.py
+++ b/search/domain/__init__.py
@@ -20,8 +20,8 @@ __all__ = [
     "Field",
     "Term",
     "Phrase",
-    "SortBy",
     "SortOrder",
+    "SortBy",
     "Query",
     "SimpleQuery",
     # advanced
@@ -52,8 +52,8 @@ from search.domain.base import (
     Field,
     Term,
     Phrase,
-    SortBy,
     SortOrder,
+    SortBy,
     Query,
     SimpleQuery,
 )

--- a/search/domain/__init__.py
+++ b/search/domain/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
     "APIQuery",
     # classic api
     "ClassicAPIQuery",
+    "ClassicSearchResponseData",
     # documenhts
     "Error",
     "Document",
@@ -60,7 +61,10 @@ from search.domain.advanced import (
     AdvancedQuery,
 )
 from search.domain.api import APIQuery
-from search.domain.classic_api import ClassicAPIQuery
+from search.domain.classic_api import (
+    ClassicAPIQuery,
+    ClassicSearchResponseData,
+)
 from search.domain.documents import (
     Error,
     Document,

--- a/search/domain/__init__.py
+++ b/search/domain/__init__.py
@@ -10,6 +10,7 @@ intelligibility of the codebase.
 
 __all__ = [
     # base
+    "asdict",
     "DocMeta",
     "Fulltext",
     "DateRange",
@@ -41,6 +42,7 @@ __all__ = [
 
 # pylint: disable=wildcard-import
 from search.domain.base import (
+    asdict,
     DocMeta,
     Fulltext,
     DateRange,

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -234,7 +234,7 @@ class SortBy(str, Enum):
     def to_es(self) -> str:
         return {
             SortBy.relevance: "_score",
-            SortBy.last_updated_date: "update_date",
+            SortBy.last_updated_date: "updated_date",
             SortBy.submitted_date: "submitted_date",
         }[self]
 

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -215,6 +215,17 @@ Examples
 """
 
 
+class SortBy(str, Enum):
+    relevance = "relevance"
+    last_updated_date = "lastUpdatedDate"
+    submitted_date = "submittedDate"
+
+
+class SortOrder(str, Enum):
+    ascending = "ascending"
+    descending = "descending"
+
+
 @dataclass
 class Query:
     """Represents a search query originating from the UI or API."""

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -1,7 +1,6 @@
 """Base domain classes for search service."""
 
 from enum import Enum
-from pytz import timezone
 from datetime import datetime
 from typing import Any, Optional, List, Dict, Union, Tuple
 from dataclasses import dataclass, field, asdict as _asdict
@@ -9,9 +8,6 @@ from dataclasses import dataclass, field, asdict as _asdict
 from mypy_extensions import TypedDict
 
 from search import consts
-
-
-EASTERN = timezone("US/Eastern")
 
 
 # FIXME: Return type.
@@ -78,10 +74,10 @@ class Fulltext:
 class DateRange:
     """Represents an open or closed date range, for use in :class:`.Query`."""
 
-    start_date: datetime = datetime(1990, 1, 1, tzinfo=EASTERN)
+    start_date: datetime = datetime(1990, 1, 1, tzinfo=consts.EASTERN)
     """The day/time on which the range begins."""
 
-    end_date: datetime = datetime.now(tz=EASTERN)
+    end_date: datetime = datetime.now(tz=consts.EASTERN)
     """The day/time at (just before) which the range ends."""
 
     SUBMITTED_ORIGINAL = "submitted_date_first"

--- a/search/domain/base.py
+++ b/search/domain/base.py
@@ -215,15 +215,29 @@ Examples
 """
 
 
+class SortOrder(str, Enum):
+    ascending = "ascending"
+    descending = "descending"
+
+
 class SortBy(str, Enum):
     relevance = "relevance"
     last_updated_date = "lastUpdatedDate"
     submitted_date = "submittedDate"
 
+    def to_es(self, order: SortOrder) -> Dict[str, Dict[str, str]]:
+        return {
+            self._table[self]: {
+                "order": "asc" if order == SortOrder.ascending else "desc"
+            }
+        }
 
-class SortOrder(str, Enum):
-    ascending = "ascending"
-    descending = "descending"
+
+SortBy._table = {
+    SortBy.relevance: "_score",
+    SortBy.last_updated_date: "update_date",
+    SortBy.submitted_date: "submitted_date",
+}
 
 
 @dataclass

--- a/search/domain/classic_api/__init__.py
+++ b/search/domain/classic_api/__init__.py
@@ -1,5 +1,8 @@
 """Classic API Query object."""
 
-__all__ = ["ClassicAPIQuery"]
+__all__ = ["ClassicAPIQuery", "ClassicSearchResponseData"]
 
-from search.domain.classic_api.classic_query import ClassicAPIQuery
+from search.domain.classic_api.classic_query import (
+    ClassicAPIQuery,
+    ClassicSearchResponseData,
+)

--- a/search/domain/classic_api/classic_query.py
+++ b/search/domain/classic_api/classic_query.py
@@ -3,7 +3,7 @@
 from typing import Optional, List
 from dataclasses import dataclass, field
 
-from search.domain.base import Query, Phrase
+from search.domain.base import SortBy, SortOrder, Query, Phrase
 from search.domain.classic_api.query_parser import parse_classic_query
 
 
@@ -11,10 +11,15 @@ from search.domain.classic_api.query_parser import parse_classic_query
 class ClassicAPIQuery(Query):
     """Query supported by the classic arXiv API."""
 
+    SortBy = SortBy
+    SortOrder = SortOrder
+
     search_query: Optional[str] = field(default=None)
     phrase: Optional[Phrase] = field(default=None)
     id_list: Optional[List[str]] = field(default=None)
     size: int = field(default=10)
+    sort_by: SortBy = field(default=SortBy.relevance)
+    sort_order: SortOrder = field(default=SortOrder.descending)
 
     def __post_init__(self) -> None:
         """Ensure that either a phrase or id_list is set."""

--- a/search/domain/classic_api/classic_query.py
+++ b/search/domain/classic_api/classic_query.py
@@ -3,6 +3,7 @@
 from typing import Optional, List
 from dataclasses import dataclass, field
 
+from search.domain.documents import DocumentSet
 from search.domain.base import SortBy, SortOrder, Query, Phrase
 from search.domain.classic_api.query_parser import parse_classic_query
 
@@ -39,3 +40,9 @@ class ClassicAPIQuery(Query):
             f"start={self.page_start}&"
             f"max_results={self.size}"
         )
+
+
+@dataclass
+class ClassicSearchResponseData:
+    results: DocumentSet = None
+    query: ClassicAPIQuery = None

--- a/search/domain/classic_api/classic_query.py
+++ b/search/domain/classic_api/classic_query.py
@@ -3,8 +3,8 @@
 from typing import Optional, List
 from dataclasses import dataclass, field
 
+from search.domain.base import Query, Phrase
 from search.domain.documents import DocumentSet
-from search.domain.base import SortBy, SortOrder, Query, Phrase
 from search.domain.classic_api.query_parser import parse_classic_query
 
 
@@ -12,15 +12,10 @@ from search.domain.classic_api.query_parser import parse_classic_query
 class ClassicAPIQuery(Query):
     """Query supported by the classic arXiv API."""
 
-    SortBy = SortBy
-    SortOrder = SortOrder
-
     search_query: Optional[str] = field(default=None)
     phrase: Optional[Phrase] = field(default=None)
     id_list: Optional[List[str]] = field(default=None)
     size: int = field(default=10)
-    sort_by: SortBy = field(default=SortBy.relevance)
-    sort_order: SortOrder = field(default=SortOrder.descending)
 
     def __post_init__(self) -> None:
         """Ensure that either a phrase or id_list is set."""

--- a/search/routes/classic_api/__init__.py
+++ b/search/routes/classic_api/__init__.py
@@ -26,7 +26,7 @@ def query() -> Response:
     # requested = request.accept_mimetypes.best_match([JSON, ATOM_XML])
     # if requested == ATOM_XML:
     #     return serialize.as_atom(data), status, headers
-    response_data = serialize.as_atom(data["results"], query=data["query"])
+    response_data = serialize.as_atom(data.results, query=data.query)
     headers.update({"Content-type": ATOM_XML})
     response: Response = make_response(response_data, status_code, headers)
     return response
@@ -37,7 +37,7 @@ def query() -> Response:
 def paper(paper_id: str, version: str) -> Response:
     """Document metadata endpoint."""
     data, status_code, headers = classic_api.paper(f"{paper_id}v{version}")
-    response_data = serialize.as_atom(data["results"])
+    response_data = serialize.as_atom(data.results)
     headers.update({"Content-type": ATOM_XML})
     response: Response = make_response(response_data, status_code, headers)
     return response

--- a/search/routes/classic_api/tests/test_classic.py
+++ b/search/routes/classic_api/tests/test_classic.py
@@ -60,10 +60,9 @@ class TestClassicAPISearchRequests(TestCase):
             "results": [document],
             "metadata": {"start": 0, "end": 1, "size": 50, "total": 1},
         }
-        r_data = {
-            "results": docs,
-            "query": domain.ClassicAPIQuery(id_list=["1234.5678"]),
-        }
+        r_data = domain.ClassicSearchResponseData(
+            results=docs, query=domain.ClassicAPIQuery(id_list=["1234.5678"])
+        )
         mock_controller.query.return_value = r_data, HTTPStatus.OK, {}
         response = self.client.get(
             "/classic_api/query?search_query=au:copernicus",
@@ -79,7 +78,9 @@ class TestClassicAPISearchRequests(TestCase):
             "results": [document],
             "metadata": {"start": 0, "end": 1, "size": 50, "total": 1},
         }
-        r_data = {"results": docs, "query": domain.APIQuery()}
+        r_data = domain.ClassicSearchResponseData(
+            results=docs, query=domain.APIQuery()
+        )
         mock_controller.paper.return_value = r_data, HTTPStatus.OK, {}
         response = self.client.get(
             "/classic_api/1234.56789v6", headers=self.auth_header

--- a/search/routes/classic_api/tests/test_classic.py
+++ b/search/routes/classic_api/tests/test_classic.py
@@ -100,7 +100,7 @@ class TestClassicAPISearchRequests(TestCase):
         return et.find(self._fix_path(path))
 
     def _text(self, et: ElementTree, path: str):
-        """Return the text content of the node"""
+        """Return the text content of the node."""
         return et.findtext(self._fix_path(path))
 
     def check_validation_error(self, response, error, link):
@@ -158,6 +158,46 @@ class TestClassicAPISearchRequests(TestCase):
             response,
             "max_results must be non-negative",
             "http://arxiv.org/api/errors#max_results_must_be_non-negative",
+        )
+
+    def test_sort_by(self):
+        for value in domain.SortBy:
+            response = self.client.get(
+                f"/classic_api/query?search_query=au:copernicus&"
+                f"sortBy={value}",
+                headers=self.auth_header,
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        response = self.client.get(
+            "/classic_api/query?search_query=au:copernicus&sortBy=foo",
+            headers=self.auth_header,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.check_validation_error(
+            response,
+            f"sortBy must be in: {', '.join(domain.SortBy)}",
+            "https://arxiv.org/help/api/user-manual#sort",
+        )
+
+    def test_sort_order(self):
+        for value in domain.SortOrder:
+            response = self.client.get(
+                f"/classic_api/query?search_query=au:copernicus&"
+                f"sortOrder={value}",
+                headers=self.auth_header,
+            )
+            self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        response = self.client.get(
+            "/classic_api/query?search_query=au:copernicus&sortOrder=foo",
+            headers=self.auth_header,
+        )
+        self.assertEqual(response.status_code, HTTPStatus.BAD_REQUEST)
+        self.check_validation_error(
+            response,
+            f"sortOrder must be in: {', '.join(domain.SortOrder)}",
+            "https://arxiv.org/help/api/user-manual#sort",
         )
 
     def test_invalid_arxiv_id(self):

--- a/search/serialize/atom.py
+++ b/search/serialize/atom.py
@@ -195,7 +195,7 @@ class AtomXMLSerializer(BaseSerializer):
         fg.opensearch.itemsPerPage(document_set["metadata"].get("size"))
         fg.opensearch.startIndex(document_set["metadata"].get("start"))
 
-        for doc in document_set["results"]:
+        for doc in reversed(document_set["results"]):
             cls.transform_document(fg, doc, query=query)
 
         return fg.atom_str(pretty=True)  # type: ignore

--- a/search/services/index/classic.py
+++ b/search/services/index/classic.py
@@ -8,7 +8,6 @@ from search.domain import (
     ClassicAPIQuery,
     Phrase,
     Term,
-    SortOrder,
     Field,
     Operator,
 )
@@ -53,16 +52,12 @@ def classic_search(search: Search, query: ClassicAPIQuery) -> Search:
             Q("terms", paper_id=paper_ids) & Q("term", is_current=True)
         ) | Q("terms", paper_id_v=paper_ids_vs)
 
-        search = search.filter(id_query).sort(
-            f"-{query.sort_by}"
-            if query.sort_order == SortOrder.descending
-            else f"{query.sort_by}"
-        )
+        search = search.filter(id_query)
     else:
         # If no id_list, only display current results.
         search = search.filter("term", is_current=True)
 
-    return search.query(dsl_query)
+    return search.query(dsl_query).sort(query.sort_by.to_es(query.sort_order))
 
 
 def _phrase_to_query(phrase: Phrase) -> Q:

--- a/search/services/index/classic.py
+++ b/search/services/index/classic.py
@@ -57,7 +57,7 @@ def classic_search(search: Search, query: ClassicAPIQuery) -> Search:
         # If no id_list, only display current results.
         search = search.filter("term", is_current=True)
 
-    return search.query(dsl_query).sort(query.sort_by.to_es(query.sort_order))
+    return search.query(dsl_query).sort(*query.order.to_es())
 
 
 def _phrase_to_query(phrase: Phrase) -> Q:

--- a/search/services/index/classic.py
+++ b/search/services/index/classic.py
@@ -4,8 +4,18 @@ from typing import Dict, Callable
 
 from elasticsearch_dsl import Q, Search
 
-from ...domain import ClassicAPIQuery, Phrase, Term, Field, Operator
-from .prepare import SEARCH_FIELDS, query_any_subject_exact_raw
+from search.domain import (
+    ClassicAPIQuery,
+    Phrase,
+    Term,
+    SortOrder,
+    Field,
+    Operator,
+)
+from search.services.index.prepare import (
+    SEARCH_FIELDS,
+    query_any_subject_exact_raw,
+)
 
 
 def classic_search(search: Search, query: ClassicAPIQuery) -> Search:
@@ -43,7 +53,11 @@ def classic_search(search: Search, query: ClassicAPIQuery) -> Search:
             Q("terms", paper_id=paper_ids) & Q("term", is_current=True)
         ) | Q("terms", paper_id_v=paper_ids_vs)
 
-        search = search.filter(id_query)
+        search = search.filter(id_query).sort(
+            f"-{query.sort_by}"
+            if query.sort_order == SortOrder.descending
+            else f"{query.sort_by}"
+        )
     else:
         # If no id_list, only display current results.
         search = search.filter("term", is_current=True)

--- a/search/services/index/results.py
+++ b/search/services/index/results.py
@@ -91,8 +91,8 @@ def to_documentset(
 
     """
     max_pages = int(MAX_RESULTS / query.size)
-    N_pages_raw = response["hits"]["total"] / query.size
-    N_pages = int(floor(N_pages_raw)) + int(N_pages_raw % query.size > 0)
+    n_pages_raw = response["hits"]["total"] / query.size
+    n_pages = int(floor(n_pages_raw)) + int(n_pages_raw % query.size > 0)
     logger.debug("got %i results", response["hits"]["total"])
     return {
         "metadata": {
@@ -102,7 +102,7 @@ def to_documentset(
             ),
             "total_results": response["hits"]["total"],
             "current_page": query.page,
-            "total_pages": N_pages,
+            "total_pages": n_pages,
             "size": query.size,
             "max_pages": max_pages,
         },

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -8,6 +8,8 @@ from search.services import index
 from search.services.index import advanced
 from search.services.index.util import wildcard_escape, Q_
 from search.domain import (
+    SortBy,
+    SortOrder,
     FieldedSearchTerm,
     DateRange,
     Classification,
@@ -249,7 +251,9 @@ class TestSearch(TestCase):
         mock_Search.__getitem__.return_value = mock_Search
 
         query = ClassicAPIQuery(
-            phrase=(Field.Author, "copernicus"), order="relevance", size=10
+            phrase=(Field.Author, "copernicus"),
+            order=SortOrder(by=SortBy.relevance),
+            size=10,
         )
 
         document_set = index.SearchSession.search(query)
@@ -288,7 +292,7 @@ class TestSearch(TestCase):
                 Operator.OR,
                 (Operator.ANDNOT, (Field.Title, "dark matter")),
             ),
-            order="relevance",
+            order=SortOrder(by=SortBy.relevance),
             size=10,
         )
 
@@ -323,7 +327,9 @@ class TestSearch(TestCase):
         mock_Search.__getitem__.return_value = mock_Search
 
         query = ClassicAPIQuery(
-            id_list=["1234.56789"], order="relevance", size=10
+            id_list=["1234.56789"],
+            order=SortOrder(by=SortBy.relevance),
+            size=10,
         )
 
         document_set = index.SearchSession.search(query)
@@ -362,7 +368,7 @@ class TestSearch(TestCase):
                 Operator.AND,
                 (Field.Title, "philosophy"),
             ),
-            order="relevance",
+            order=SortOrder(by=SortBy.relevance),
             size=10,
         )
 

--- a/search/services/index/tests/tests.py
+++ b/search/services/index/tests/tests.py
@@ -1,6 +1,5 @@
 """Tests for :mod:`search.services.index`."""
 
-from pytz import timezone
 from unittest import TestCase, mock
 from datetime import datetime, timedelta
 
@@ -21,8 +20,6 @@ from search.domain import (
     ClassicAPIQuery,
     Operator,
 )
-
-EASTERN = timezone("US/Eastern")
 
 
 class TestClassicApiQuery(TestCase):

--- a/search/services/index/util.py
+++ b/search/services/index/util.py
@@ -7,6 +7,7 @@ from typing import Optional, Tuple
 
 from elasticsearch_dsl import Search, Q
 
+from search import consts
 from search.domain import Query
 from search.services.index.exceptions import QueryError
 
@@ -42,7 +43,6 @@ SPECIAL_CHARACTERS = [
     "/",
     "-",
 ]
-DEFAULT_SORT = ["-announced_date_first", "_doc"]
 
 DATE_PARTIAL = r"(?:^|[\s])(\d{2})((?:0[1-9]{1})|(?:1[0-2]{1}))(?:$|[\s])"
 """Used to match parts of paper IDs that encode the announcement date."""
@@ -159,7 +159,7 @@ def remove_single_characters(term: str) -> str:
 def sort(query: Query, search: Search) -> Search:
     """Apply sorting to a :class:`.Search`."""
     if not query.order:
-        sort_params = DEFAULT_SORT
+        sort_params = consts.DEFAULT_SORT_ORDER
     else:
         direction = "-" if query.order.startswith("-") else ""
         sort_params = [query.order, f"{direction}paper_id_v"]


### PR DESCRIPTION
1. I'm gradually introducing structures where dictionaries were used before.
2. Added `SortBy`, `SortDirection` and `SortOrder` so now `order` field on `Query` can be `SortOrder`.
3. Added sorting to classical api.
4. Reversed the list in the atom generation because it reverses it when it adds items, so this keeps the sorting order.