### PR TITLE
Remove all references to deprecated arxiv.status module.

### DIFF
--- a/search/controllers/__init__.py
+++ b/search/controllers/__init__.py
@@ -7,8 +7,9 @@ accepts a set of request parameters (``dict``-like) and returns a 3-tuple
 of response data (``dict``), status code (``int``), and extra response headers
 (``dict``).
 """
+from http import HTTPStatus
 from typing import Tuple, Dict, Any
-from arxiv import status
+
 from search.services import index
 from search.domain import SimpleQuery
 
@@ -32,7 +33,7 @@ def health_check() -> Tuple[str, int, Dict[str, Any]]:
             SimpleQuery(search_field="all", value="theory")
         )
     except Exception:
-        return "DOWN", status.HTTP_500_INTERNAL_SERVER_ERROR, {}
+        return "DOWN", HTTPStatus.INTERNAL_SERVER_ERROR, {}
     if document_set["results"]:
-        return "OK", status.HTTP_200_OK, {}
-    return "DOWN", status.HTTP_500_INTERNAL_SERVER_ERROR, {}
+        return "OK", HTTPStatus.OK, {}
+    return "DOWN", HTTPStatus.INTERNAL_SERVER_ERROR, {}

--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -8,6 +8,7 @@ parameters, and produce informative error messages for the user.
 """
 
 import re
+from http import HTTPStatus
 from typing import Tuple, List, Dict, Any, Optional
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
@@ -17,7 +18,7 @@ from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 from werkzeug.exceptions import InternalServerError, BadRequest, NotFound
 
 
-from arxiv import status, taxonomy
+from arxiv import taxonomy
 from arxiv.base import logging
 from search.services import index, SearchSession
 from search.domain import (
@@ -170,7 +171,7 @@ def search(request_params: MultiDict) -> Response:
     #  example, we can generate new form-friendly requests to update sort
     #  order and page size by embedding the form (hidden).
     response_data["form"] = form
-    return response_data, status.HTTP_200_OK, {}
+    return response_data, HTTPStatus.OK, {}
 
 
 def _query_from_form(form: forms.AdvancedSearchForm) -> AdvancedQuery:

--- a/search/controllers/advanced/tests.py
+++ b/search/controllers/advanced/tests.py
@@ -1,12 +1,13 @@
 """Tests for advanced search controller, :mod:`search.controllers.advanced`."""
 
+from http import HTTPStatus
 from unittest import TestCase, mock
 from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
+
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import InternalServerError, BadRequest
 
-from arxiv import status
 
 from search.domain import Query, DateRange, FieldedSearchTerm, AdvancedQuery
 from search.controllers import advanced
@@ -76,7 +77,7 @@ class TestSearchController(TestCase):
         """No form data has been submitted."""
         request_data = MultiDict()
         response_data, code, headers = advanced.search(request_data)
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
         self.assertIn("form", response_data, "Response should include form.")
 
@@ -107,7 +108,7 @@ class TestSearchController(TestCase):
             AdvancedQuery,
             "An AdvancedQuery is passed to the search index",
         )
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
     @mock.patch("search.controllers.advanced.SearchSession")
     def test_invalid_data(self, mock_index):
@@ -121,7 +122,7 @@ class TestSearchController(TestCase):
             }
         )
         response_data, code, headers = advanced.search(request_data)
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
         self.assertIn("form", response_data, "Response should include form.")
 

--- a/search/controllers/api/__init__.py
+++ b/search/controllers/api/__init__.py
@@ -1,6 +1,7 @@
 """Controller for search API requests."""
 
 import pytz
+from http import HTTPStatus
 from collections import defaultdict
 from typing import Tuple, Dict, Any, Optional, List, Union
 
@@ -9,7 +10,7 @@ from mypy_extensions import TypedDict
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import BadRequest, NotFound
 
-from arxiv import status, taxonomy
+from arxiv import taxonomy
 from arxiv.base import logging
 
 from search import consts
@@ -111,7 +112,7 @@ def search(params: MultiDict) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     logger.debug(
         "Got document set with %i results", len(document_set["results"])
     )
-    return {"results": document_set, "query": q}, status.HTTP_200_OK, {}
+    return {"results": document_set, "query": q}, HTTPStatus.OK, {}
 
 
 def paper(paper_id: str) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
@@ -145,7 +146,7 @@ def paper(paper_id: str) -> Tuple[Dict[str, Any], int, Dict[str, Any]]:
     except index.DocumentNotFound as ex:
         logger.error("Document not found")
         raise NotFound("No such document") from ex
-    return {"results": document}, status.HTTP_200_OK, {}
+    return {"results": document}, HTTPStatus.OK, {}
 
 
 def _get_include_fields(params: MultiDict, query_terms: List) -> List[str]:

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -7,14 +7,15 @@ to generate form HTML, validate request parameters, and produce informative
 error messages for the user.
 """
 
+from http import HTTPStatus
 from typing import Tuple, Dict, Any, Optional, List
 
 from flask import url_for
 from werkzeug.exceptions import InternalServerError, NotFound, BadRequest
 from werkzeug.datastructures import MultiDict, ImmutableMultiDict
 
+from arxiv import identifier
 from arxiv.base import logging
-from arxiv import status, identifier
 from search.services import index, SearchSession
 from search.controllers.simple.forms import SimpleSearchForm
 from search.controllers.util import paginate, catch_underscore_syntax
@@ -93,7 +94,7 @@ def search(
 
     if arxiv_id:
         headers = {"Location": url_for("abs_by_id", paper_id=arxiv_id)}
-        return {}, status.HTTP_301_MOVED_PERMANENTLY, headers
+        return {}, HTTPStatus.MOVED_PERMANENTLY, headers
 
     # Here we intervene on the user's query to look for holdouts from the
     # classic search system's author indexing syntax (surname_f). We
@@ -114,7 +115,7 @@ def search(
         if form.searchtype.data == "help":
             return (
                 {},
-                status.HTTP_301_MOVED_PERMANENTLY,
+                HTTPStatus.MOVED_PERMANENTLY,
                 {"Location": f"/help/search?q={form.query.data}"},
             )
 
@@ -122,7 +123,7 @@ def search(
         elif form.searchtype.data == "full_text":
             return (
                 {},
-                status.HTTP_301_MOVED_PERMANENTLY,
+                HTTPStatus.MOVED_PERMANENTLY,
                 {
                     "Location": "http://search.arxiv.org:8081/"
                     f"?in=&query={form.query.data}"
@@ -188,7 +189,7 @@ def search(
         q = None
     response_data["query"] = q
     response_data["form"] = form
-    return response_data, status.HTTP_200_OK, {}
+    return response_data, HTTPStatus.OK, {}
 
 
 def retrieve_document(document_id: str) -> Response:
@@ -241,7 +242,7 @@ def retrieve_document(document_id: str) -> Response:
     except index.DocumentNotFound as ex:
         logger.error("DocumentNotFound: %s", ex)
         raise NotFound(f"Could not find a paper with id {document_id}") from ex
-    return {"document": result}, status.HTTP_200_OK, {}
+    return {"document": result}, HTTPStatus.OK, {}
 
 
 def _update_with_archives(q: SimpleQuery, archives: List[str]) -> SimpleQuery:

--- a/search/controllers/simple/tests.py
+++ b/search/controllers/simple/tests.py
@@ -1,10 +1,11 @@
 """Tests for simple search controller, :mod:`search.controllers.simple`."""
 
+from http import HTTPStatus
 from unittest import TestCase, mock
+
 from werkzeug.datastructures import MultiDict
 from werkzeug.exceptions import InternalServerError, NotFound, BadRequest
 
-from arxiv import status
 from search.domain import SimpleQuery
 from search.controllers import simple
 from search.controllers.simple.forms import SimpleSearchForm
@@ -94,7 +95,7 @@ class TestSearchController(TestCase):
         response_data, code, headers = simple.search(request_data)
         self.assertEqual(
             code,
-            status.HTTP_301_MOVED_PERMANENTLY,
+            HTTPStatus.MOVED_PERMANENTLY,
             "Response should be a 301 redirect.",
         )
         self.assertIn("Location", headers, "Location header should be set")
@@ -108,7 +109,7 @@ class TestSearchController(TestCase):
         """No form data has been submitted."""
         request_data = MultiDict()
         response_data, code, headers = simple.search(request_data)
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
         self.assertIn("form", response_data, "Response should include form.")
 
@@ -131,14 +132,14 @@ class TestSearchController(TestCase):
             SimpleQuery,
             "An SimpleQuery is passed to the search index",
         )
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
     @mock.patch("search.controllers.simple.SearchSession")
     def test_invalid_data(self, mock_index):
         """Form data are invalid."""
         request_data = MultiDict({"searchtype": "title"})
         response_data, code, headers = simple.search(request_data)
-        self.assertEqual(code, status.HTTP_200_OK, "Response should be OK.")
+        self.assertEqual(code, HTTPStatus.OK, "Response should be OK.")
 
         self.assertIn("form", response_data, "Response should include form.")
 
@@ -157,7 +158,7 @@ class TestSearchController(TestCase):
 
         request_data = MultiDict({"searchtype": "title", "query": "foo title"})
         with self.assertRaises(InternalServerError):
-            response_data, code, headers = simple.search(request_data)
+            _, _, _ = simple.search(request_data)
 
         self.assertEqual(
             mock_index.search.call_count, 1, "A search should be attempted"

--- a/search/controllers/tests.py
+++ b/search/controllers/tests.py
@@ -1,8 +1,8 @@
 """Tests for :mod:`search.controllers`."""
 
+from http import HTTPStatus
 from unittest import TestCase, mock
 
-from arxiv import status
 from search.controllers import health_check
 from search.controllers.util import catch_underscore_syntax
 
@@ -18,7 +18,7 @@ class TestHealthCheck(TestCase):
         self.assertEqual(response, "DOWN", "Response content should be DOWN")
         self.assertEqual(
             status_code,
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
             "Should return 500 status code.",
         )
 
@@ -30,7 +30,7 @@ class TestHealthCheck(TestCase):
         self.assertEqual(response, "DOWN", "Response content should be DOWN")
         self.assertEqual(
             status_code,
-            status.HTTP_500_INTERNAL_SERVER_ERROR,
+            HTTPStatus.INTERNAL_SERVER_ERROR,
             "Should return 500 status code.",
         )
 
@@ -41,7 +41,7 @@ class TestHealthCheck(TestCase):
         response, status_code, _ = health_check()
         self.assertEqual(response, "OK", "Response content should be OK")
         self.assertEqual(
-            status_code, status.HTTP_200_OK, "Should return 200 status code."
+            status_code, HTTPStatus.OK, "Should return 200 status code."
         )
 
 

--- a/search/routes/api/tests/test_api.py
+++ b/search/routes/api/tests/test_api.py
@@ -2,13 +2,13 @@
 
 import os
 import json
+from http import HTTPStatus
 from unittest import TestCase, mock
 
 import jsonschema
 
 from arxiv.users import helpers, auth
 from arxiv.users.domain import Scope
-from arxiv import status
 
 from search import factory
 from search.tests import mocks
@@ -34,7 +34,7 @@ class TestAPISearchRequests(TestCase):
     def test_request_without_token(self):
         """No auth token is provided on the request."""
         response = self.client.get("/")
-        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.status_code, HTTPStatus.UNAUTHORIZED)
 
     def test_with_token_lacking_scope(self):
         """Client auth token lacks required public read scope."""
@@ -45,7 +45,7 @@ class TestAPISearchRequests(TestCase):
             scope=[Scope("something", "read")],
         )
         response = self.client.get("/", headers={"Authorization": token})
-        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, HTTPStatus.FORBIDDEN)
 
     @mock.patch(f"{factory.__name__}.api.api")
     def test_with_valid_token(self, mock_controller):
@@ -56,12 +56,12 @@ class TestAPISearchRequests(TestCase):
             "metadata": {"start": 0, "end": 1, "size": 50, "total": 1},
         }
         r_data = {"results": docs, "query": APIQuery()}
-        mock_controller.search.return_value = r_data, status.HTTP_200_OK, {}
+        mock_controller.search.return_value = r_data, HTTPStatus.OK, {}
         token = helpers.generate_token(
             "1234", "foo@bar.com", "foouser", scope=[auth.scopes.READ_PUBLIC]
         )
         response = self.client.get("/", headers={"Authorization": token})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         data = json.loads(response.data)
         res = jsonschema.RefResolver(
@@ -87,12 +87,12 @@ class TestAPISearchRequests(TestCase):
 
         query = APIQuery(include_fields=["abstract", "license"])
         r_data = {"results": docs, "query": query}
-        mock_controller.search.return_value = r_data, status.HTTP_200_OK, {}
+        mock_controller.search.return_value = r_data, HTTPStatus.OK, {}
         token = helpers.generate_token(
             "1234", "foo@bar.com", "foouser", scope=[auth.scopes.READ_PUBLIC]
         )
         response = self.client.get("/", headers={"Authorization": token})
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         data = json.loads(response.data)
         res = jsonschema.RefResolver(
@@ -118,14 +118,14 @@ class TestAPISearchRequests(TestCase):
             "metadata": {"start": 0, "end": 1, "size": 50, "total": 1},
         }
         r_data = {"results": docs, "query": APIQuery()}
-        mock_controller.paper.return_value = r_data, status.HTTP_200_OK, {}
+        mock_controller.paper.return_value = r_data, HTTPStatus.OK, {}
         token = helpers.generate_token(
             "1234", "foo@bar.com", "foouser", scope=[auth.scopes.READ_PUBLIC]
         )
         response = self.client.get(
             "/1234.56789v6", headers={"Authorization": token}
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, HTTPStatus.OK)
 
         data = json.loads(response.data)
         res = jsonschema.RefResolver(

--- a/search/services/fulltext.py
+++ b/search/services/fulltext.py
@@ -1,12 +1,12 @@
 """Provides access to fulltext content for arXiv papers."""
 
 import json
+from http import HTTPStatus
 from functools import wraps
 from urllib.parse import urljoin
 
 import requests
 
-from arxiv import status
 from search.domain import Fulltext
 from search.context import get_application_config, get_application_global
 
@@ -56,7 +56,7 @@ class FulltextSession(object):
         except requests.exceptions.SSLError as ex:
             raise IOError("SSL failed: %s" % ex)
 
-        if response.status_code != status.HTTP_200_OK:
+        if response.status_code != HTTPStatus.OK:
             raise IOError(
                 "%s: could not retrieve fulltext: %i"
                 % (document_id, response.status_code)

--- a/search/services/metadata.py
+++ b/search/services/metadata.py
@@ -13,6 +13,7 @@ depending on the context of the request.
 import ast
 import json
 from typing import List
+from http import HTTPStatus
 from itertools import cycle
 from functools import wraps
 from urllib.parse import urljoin
@@ -20,7 +21,6 @@ from urllib.parse import urljoin
 import requests
 from requests.packages.urllib3.util.retry import Retry
 
-from arxiv import status
 from arxiv.base import logging
 from search.domain import DocMeta
 from search.context import get_application_config, get_application_global
@@ -124,8 +124,8 @@ class DocMetaSession(object):
             ) from ex
 
         if response.status_code not in [
-            status.HTTP_200_OK,
-            status.HTTP_206_PARTIAL_CONTENT,
+            HTTPStatus.OK,
+            HTTPStatus.PARTIAL_CONTENT,
         ]:
             logger.error("Request failed: %s", response.content)
             raise RequestFailed(
@@ -185,8 +185,8 @@ class DocMetaSession(object):
             ) from ex
 
         if response.status_code not in [
-            status.HTTP_200_OK,
-            status.HTTP_206_PARTIAL_CONTENT,
+            HTTPStatus.OK,
+            HTTPStatus.PARTIAL_CONTENT,
         ]:
             logger.error("Request failed: %s", response.content)
             raise RequestFailed(

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,10 +1,10 @@
 """Tests exception handling in :mod:`arxiv.base.exceptions`."""
 
+from http import HTTPStatus
 from unittest import TestCase, mock
 
 from werkzeug.exceptions import InternalServerError
 
-from arxiv import status
 from search.controllers import simple
 from search.factory import create_ui_web_app
 from search.services.index import IndexConnectionError, QueryError
@@ -21,15 +21,13 @@ class TestExceptionHandling(TestCase):
     def test_404(self):
         """A 404 response should be returned."""
         response = self.client.get("/foo")
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, HTTPStatus.NOT_FOUND)
         self.assertIn("text/html", response.content_type)
 
     def test_405(self):
         """A 405 response should be returned."""
         response = self.client.post("/")
-        self.assertEqual(
-            response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED
-        )
+        self.assertEqual(response.status_code, HTTPStatus.METHOD_NOT_ALLOWED)
         self.assertIn("text/html", response.content_type)
 
     @mock.patch("search.controllers.simple.search")
@@ -40,7 +38,7 @@ class TestExceptionHandling(TestCase):
 
         response = self.client.get("/")
         self.assertEqual(
-            response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
+            response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
         )
         self.assertIn("text/html", response.content_type)
 
@@ -50,7 +48,7 @@ class TestExceptionHandling(TestCase):
         mock_search.side_effect = IndexConnectionError
         response = self.client.get("/?searchtype=title&query=foo")
         self.assertEqual(
-            response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
+            response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
         )
         self.assertIn("text/html", response.content_type)
 
@@ -60,6 +58,6 @@ class TestExceptionHandling(TestCase):
         mock_search.side_effect = QueryError
         response = self.client.get("/?searchtype=title&query=foo")
         self.assertEqual(
-            response.status_code, status.HTTP_500_INTERNAL_SERVER_ERROR
+            response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
         )
         self.assertIn("text/html", response.content_type)


### PR DESCRIPTION
As the `arxiv.status` module is deprecated I removed all references in the `arixiv.search` to that module.