### PR TITLE
Quiet bulk indexing without cache

### DIFF
--- a/bulk_index.py
+++ b/bulk_index.py
@@ -19,6 +19,7 @@ app = create_ui_web_app()
 
 get_paper_id = operator.attrgetter("paper_id")
 
+
 @app.cli.command()
 @click.option(
     "--print_indexable",
@@ -84,7 +85,7 @@ def populate(
                 else:
                     chunk.append(paper_id)
 
-                if len(chunk) == retrieve_chunk_size or i == last:
+                if len(chunk) == retrieve_chunk_size or (chunk and i == last):
                     try:
                         new_meta = metadata.bulk_retrieve(chunk)
                     except metadata.ConnectionFailed:  # Try again.
@@ -205,6 +206,8 @@ def load_id_sample() -> List[str]:
 
 
 class NoopContextManager(object):
+    """Context manager that does nothing to replace click progressbar in
+    quiet mode."""
     def __enter__(self):
         return self
 

--- a/bulk_index.py
+++ b/bulk_index.py
@@ -17,7 +17,7 @@ from search.factory import create_ui_web_app
 
 app = create_ui_web_app()
 
-paper_id = operator.attrgetter("paper_id")
+get_paper_id = operator.attrgetter("paper_id")
 
 @app.cli.command()
 @click.option(
@@ -52,7 +52,6 @@ def populate(
 
     if not no_cache:
         cache_dir = init_cache(cache_dir)
-        print(f" cache_dir is {cache_dir}")  # wip
     else:
         cache_dir = None
 
@@ -95,8 +94,8 @@ def populate(
                     chunk = []
                     if not no_cache:
                         # Add metadata to the cache.
-                        new_meta_srt = sorted(new_meta, key=paper_id)
-                        for paper_id, grp in groupby(new_meta_srt, paper_id):
+                        new_meta_srt = sorted(new_meta, key=get_paper_id)
+                        for paper_id, grp in groupby(new_meta_srt, get_paper_id):
                             to_cache(cache_dir, paper_id, [dm for dm in grp])
 
                 # Index papers on a different chunk cycle, and at the very end.

--- a/bulk_index.py
+++ b/bulk_index.py
@@ -119,10 +119,6 @@ def populate(
                     index_count += len(docs)
                     meta = []
                     index_bar.update(i)
-
-    except Exception as ex:
-        raise RuntimeError("bulk_index failed: %s" % str(ex)) from ex
-
     finally:
         if not quiet:
             click.echo(f"Indexed {index_count} documents in total")

--- a/bulk_index.py
+++ b/bulk_index.py
@@ -17,13 +17,14 @@ from search.factory import create_ui_web_app
 
 app = create_ui_web_app()
 
+paper_id = operator.attrgetter("paper_id")
 
 @app.cli.command()
 @click.option(
     "--print_indexable",
     "-i",
     is_flag=True,
-    help="Print the indexable JSON to stdout.",
+    help="Index to ES and print the indexable JSON to stdout.",
 )
 @click.option("--paper_id", "-p", help="Index specified paper id")
 @click.option(
@@ -38,15 +39,30 @@ app = create_ui_web_app()
     " in the cache.",
 )
 @click.option("--cache-dir", "-c", help="Specify the cache directory.")
+@click.option("--no-cache", help="Disable the cache feature",
+              is_flag=True, default=False)
+@click.option("--quiet", "-q", help="Only print on failure",
+              is_flag=True, default=False)
 def populate(
     print_indexable: bool,
     paper_id: str,
     id_list: str,
     load_cache: bool,
     cache_dir: str,
+    no_cache: bool,
+    quiet: bool,
 ) -> None:
     """Populate the search index with some test data."""
-    cache_dir = init_cache(cache_dir)
+    if cache_dir and no_cache:
+        raise RuntimeError("Cannot set both no cache and cache dir")
+    if no_cache and load_cache:
+        raise RuntimeError("Cannot set both load cache and no cache")
+
+    if not no_cache:
+        cache_dir = init_cache(cache_dir)
+    else:
+        cache_dir = None
+
     index_count = 0
     if paper_id:  # Index a single paper.
         TO_INDEX = [paper_id]
@@ -61,18 +77,15 @@ def populate(
     chunk: List[str] = []
     meta: List[DocMeta] = []
     index.SearchSession.create_index()
+    progress = NoopContextManager() if quiet \
+        else click.progressbar(length=approx_size)
     try:
-        with click.progressbar(
-            length=approx_size, label="Papers indexed"
-        ) as index_bar:
+        with progress as index_bar:
             last = len(TO_INDEX) - 1
             for i, paper_id in enumerate(TO_INDEX):
                 this_meta = []
                 if load_cache:
-                    try:
-                        this_meta = from_cache(cache_dir, paper_id)
-                    except RuntimeError:  # No document.
-                        pass
+                    this_meta = from_cache(cache_dir, paper_id)
 
                 if this_meta:
                     meta += this_meta
@@ -84,39 +97,39 @@ def populate(
                         new_meta = metadata.bulk_retrieve(chunk)
                     except metadata.ConnectionFailed:  # Try again.
                         new_meta = metadata.bulk_retrieve(chunk)
-                    # Add metadata to the cache.
-                    key = operator.attrgetter("paper_id")
-                    new_meta_srt = sorted(new_meta, key=key)
-                    for paper_id, grp in groupby(new_meta_srt, key):
-                        to_cache(cache_dir, paper_id, [dm for dm in grp])
+
                     meta += new_meta
                     chunk = []
+                    if not no_cache:
+                        # Add metadata to the cache.
+                        new_meta_srt = sorted(new_meta, key=paper_id)
+                        for paper_id, grp in groupby(new_meta_srt, paper_id):
+                            to_cache(cache_dir, paper_id, [dm for dm in grp])
 
                 # Index papers on a different chunk cycle, and at the very end.
                 if len(meta) >= index_chunk_size or i == last:
                     # Transform to Document.
-                    documents = [
-                        transform.to_search_document(dm) for dm in meta
-                    ]
+                    docs = [transform.to_search_document(dm) for dm in meta]
                     # Add to index.
-                    index.SearchSession.bulk_add_documents(documents)
+                    index.SearchSession.bulk_add_documents(docs)
 
                     if print_indexable:
-                        for document in documents:
-                            click.echo(json.dumps(asdict(document)))
-                    index_count += len(documents)
+                        for document in docs:
+                            click.echo(json.dumps(asdict(docs)))
+                    index_count += len(docs)
                     meta = []
                     index_bar.update(i)
 
     except Exception as ex:
-        raise RuntimeError("Populate failed: %s" % str(ex)) from ex
+        raise RuntimeError("bulk_index failed: %s" % str(ex)) from ex
 
     finally:
-        click.echo(f"Indexed {index_count} documents in total")
-        click.echo(
-            f"Cache path: {cache_dir}; use `-c {cache_dir}` to reuse in"
-            f" subsequent calls"
-        )
+        if not quiet:
+            click.echo(f"Indexed {index_count} documents in total")
+            if cache_dir:
+                click.echo(
+                    f"Cache path: {cache_dir}; use `-c {cache_dir}` to reuse in"
+                    f" subsequent calls")
 
 
 def init_cache(cache_dir: str) -> None:
@@ -141,24 +154,23 @@ def from_cache(cache_dir: str, arxiv_id: str) -> List[DocMeta]:
 
     Returns
     -------
-    :class:`.DocMeta`
-
-    Raises
-    ------
-    RuntimeError
-        Raised when the cache is not available, or the document could not
-        be found in the cache.
+    :class:`.DocMeta` or None if document is not found in cache    
 
     """
-    fname = "%s.json" % arxiv_id.replace("/", "_")
-    cache_path = os.path.join(cache_dir, fname)
-    if not os.path.exists(cache_path):
-        raise RuntimeError("No cached document")
+    try:
+        if not cache_dir:
+            return [] # caching is disabled
+        fname = "%s.json" % arxiv_id.replace("/", "_")
+        cache_path = os.path.join(cache_dir, fname)
+        if not os.path.exists(cache_path):
+            raise RuntimeError("No cached document")
 
-    with open(cache_path) as f:
-        data: dict = json.load(f)
-        return [DocMeta(**datum) for datum in data]  # type: ignore
-        # See https://github.com/python/mypy/issues/3937
+        with open(cache_path) as f:
+            data: dict = json.load(f)
+            return [DocMeta(**datum) for datum in data]  # type: ignore
+            # See https://github.com/python/mypy/issues/3937
+    except RuntimeError:
+        return []
 
 
 def to_cache(cache_dir: str, arxiv_id: str, docmeta: List[DocMeta]) -> None:
@@ -177,6 +189,8 @@ def to_cache(cache_dir: str, arxiv_id: str, docmeta: List[DocMeta]) -> None:
         be added to the cache.
 
     """
+    if not cache_dir:
+        return
     fname = "%s.json" % arxiv_id.replace("/", "_")
     cache_path = os.path.join(cache_dir, fname)
     try:
@@ -200,6 +214,17 @@ def load_id_sample() -> List[str]:
     """Load a list of IDs from the testing sample."""
     with open("tests/data/sample.json") as f:
         return [datum["id"] for datum in json.load(f).get("sample")]
+
+
+class NoopContextManager(object):
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        pass
+
+    def update(self, i):
+        pass
 
 
 if __name__ == "__main__":

--- a/bulk_index.py
+++ b/bulk_index.py
@@ -30,15 +30,10 @@ paper_id = operator.attrgetter("paper_id")
 @click.option(
     "--id_list", "-l", help="Index paper IDs in a file (one ID per line)"
 )
-@click.option(
-    "--load-cache",
-    "-d",
-    is_flag=True,
-    help="Install papers from a cache on disk. Note: this will"
-    " preempt checking for new versions of papers that are"
-    " in the cache.",
-)
-@click.option("--cache-dir", "-c", help="Specify the cache directory.")
+@click.option("--cache-dir", "-c", help="Specify the cache directory."
+              " Install papers from a cache on disk. Note: this will"
+              " preempt checking for new versions of papers that are"
+              " in the cache.")
 @click.option("--no-cache", help="Disable the cache feature",
               is_flag=True, default=False)
 @click.option("--quiet", "-q", help="Only print on failure",
@@ -47,7 +42,6 @@ def populate(
     print_indexable: bool,
     paper_id: str,
     id_list: str,
-    load_cache: bool,
     cache_dir: str,
     no_cache: bool,
     quiet: bool,
@@ -55,11 +49,10 @@ def populate(
     """Populate the search index with some test data."""
     if cache_dir and no_cache:
         raise RuntimeError("Cannot set both no cache and cache dir")
-    if no_cache and load_cache:
-        raise RuntimeError("Cannot set both load cache and no cache")
 
     if not no_cache:
         cache_dir = init_cache(cache_dir)
+        print(f" cache_dir is {cache_dir}")  # wip
     else:
         cache_dir = None
 
@@ -84,7 +77,7 @@ def populate(
             last = len(TO_INDEX) - 1
             for i, paper_id in enumerate(TO_INDEX):
                 this_meta = []
-                if load_cache:
+                if cache_dir:
                     this_meta = from_cache(cache_dir, paper_id)
 
                 if this_meta:


### PR DESCRIPTION
This adds --quiet and --no-cache to bulk_index.py
 
See https://arxiv-org.atlassian.net/browse/ARXIVNG-3760