### PR TITLE
fixes display of boolean operator in advanced search form

### DIFF
--- a/search/static/css/search.css
+++ b/search/static/css/search.css
@@ -1,3 +1,8 @@
+.fieldset-hidden-on-first-row:first-child {
+  width: 0px;
+  visibility: hidden;
+}
+
 .content .arxiv-result {
   margin-bottom: 1.25em; }
   .content .arxiv-result p {

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -38,8 +38,7 @@
             <legend class="legend">Search term(s)</legend>
             {% for entry in form.terms.entries %}
               <div class="field has-addons-tablet" data-toggle="fieldset-entry">
-                <div class="control fieldset-hidden-on-first-row"
-                  {% if loop.index0 == 0 %}style="visibility:hidden;width:0;"{% endif %}>
+                <div class="control fieldset-hidden-on-first-row">
                   <span class="select">
                     <label for="terms-{{loop.index0}}-operator" class="hidden-label">Boolean operator</label>
                     {{ entry.operator(default='AND')|safe }}


### PR DESCRIPTION
Two small changes to fix the display of the boolean operator in the advanced search.

A new css rule hides it only for the first row. And an inline css rule in the form is removed because it was hiding it on all rows.