### PR TITLE
Change HTTP response code for queries that cannot run from 500 to 400 

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ index. Note that you will need to have access to the /docmeta endpoint, which
 is only accessible from the CUL network.
 
 ```bash
-pipenv install
+pipenv install --dev
 FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run python create_index.py
 FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run python bulk_index.py
 ```

--- a/README.md
+++ b/README.md
@@ -2,33 +2,10 @@
 
 ## Development quickstart
 
-### Running Elasticsearch + Kibana with docker-compose
+### Running Elasticsearch in Docker
 
-The easiest way to spin up ES and Kibana is using the included
-``docker-compose.yml`` file. This will start ES and Kibana on a custom network.
-The ES service ports 9200 and 9300, and Kibana service port 5601, will be
-mapped to localhost.
-
-```bash
-docker-compose up
-```
-Kibana will be available at http://127.0.0.1:5601/. The containers started by
-docker-compose can be stopped with ``docker-compose down`` from the same
-directory.
-
-Make sure that you have a recent version of ``docker-compose``; this is
-confirmed to work with version 1.18.
-
-Note that connection configuration variables for the search service are set in
-``search/config.py``, where they are read from the environment. The arXiv
-search service expects the ES service to be available at http://localhost:9200
-by default. Hence, you should be able to start ES using docker-compose as above
-and make no configuration changes to the arXiv search service.
-
-#### Running Elasticsearch without Kibana
-
-Alternatively, you can start up ES on its own. Be sure to map port 9200 to
-the host machine, so that arXiv search can find it.
+You can start up ES on its own. Be sure to map port 9200 to the host
+machine, so that arXiv search can find it.
 
 ```bash
 docker build -t "arxiv/elasticsearch" -f ./Dockerfile-elasticsearch .
@@ -54,25 +31,6 @@ FLASK_APP=app.py FLASK_DEBUG=1 ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run p
 list of papers defined in ``tests/data/sample.json``. It take several minutes
 to run. Individual paper IDs may be specified with the ``--paper_id``
 parameter.
-
-To check for missing records, use ``audit.py``:
-
-```bash
-ELASTICSEARCH_SERVICE_HOST=127.0.0.1 ELASTICSEARCH_INDEX=arxiv pipenv run python audit.py -l list_of_papers.txt -o missing.txt
-```
-
-### Reindexing
-
-ElasticSearch can perform reindexing by copying documents from one index to
-another index with a different mapping. ``reindex.py`` will initiate the
-reindexing process, and poll for completion until all of the documents are
-processed. If the destination index does not already exist, it will be created
-using the current configured mapping.
-
-```bash
-FLASK_APP=app.py ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run python reindex.py OLD_INDEX NEW_INDEX
-```
-
 
 ### Flask dev server
 
@@ -100,6 +58,28 @@ To run the classic API in dev mode, use ``wsgi-classic-api.py``:
 FLASK_APP=classic-api.py FLASK_DEBUG=1 ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run flask run
 ```
 
+## Running Elasticsearch + Kibana with docker-compose
+
+The easiest way to spin up ES and Kibana is using the included
+``docker-compose.yml`` file. This will start ES and Kibana on a custom network.
+The ES service ports 9200 and 9300, and Kibana service port 5601, will be
+mapped to localhost.
+
+```bash
+docker-compose up
+```
+Kibana will be available at http://127.0.0.1:5601/. The containers started by
+docker-compose can be stopped with ``docker-compose down`` from the same
+directory.
+
+Make sure that you have a recent version of ``docker-compose``; this is
+confirmed to work with version 1.18.
+
+Note that connection configuration variables for the search service are set in
+``search/config.py``, where they are read from the environment. The arXiv
+search service expects the ES service to be available at http://localhost:9200
+by default. Hence, you should be able to start ES using docker-compose as above
+and make no configuration changes to the arXiv search service.
 
 ## Running the indexing agent.
 
@@ -197,6 +177,26 @@ agent            | application 12/Apr/2018:15:49:24 +0000 - search.agent.consume
 agent            | application 12/Apr/2018:15:49:25 +0000 - search.agent.consumer - None - [arxiv:null] - INFO: "Processing record 49583482484923667520018808447539393315437191546590461954"
 agent            | application 12/Apr/2018:15:49:25 +0000 - search.agent.consumer - None - [arxiv:null] - INFO: "Processing record 49583482484923667520018808447540602241256806175765168130"
 agent            | application 12/Apr/2018:15:49:25 +0000 - search.agent.consumer - None - [arxiv:null] - INFO: "Processing record 49583482484923667520018808447541811167076420804939874306"
+```
+
+## Other Operations
+### Audit
+To check for missing records, put the IDs in a file like `list_of_papers.txt`, use ``audit.py``:
+
+```bash
+ELASTICSEARCH_SERVICE_HOST=127.0.0.1 ELASTICSEARCH_INDEX=arxiv pipenv run python audit.py -l list_of_papers.txt -o missing.txt
+```
+
+### Reindexing
+
+ElasticSearch can perform reindexing by copying documents from one index to
+another index with a different mapping. ``reindex.py`` will initiate the
+reindexing process, and poll for completion until all of the documents are
+processed. If the destination index does not already exist, it will be created
+using the current configured mapping.
+
+```bash
+FLASK_APP=app.py ELASTICSEARCH_SERVICE_HOST=127.0.0.1 pipenv run python reindex.py OLD_INDEX NEW_INDEX
 ```
 
 ## Deploying static assets to S3

--- a/search/controllers/advanced/__init__.py
+++ b/search/controllers/advanced/__init__.py
@@ -136,11 +136,9 @@ def search(request_params: MultiDict) -> Response:
                     "to help@arxiv.org."
                 ) from ex
             except index.QueryError as ex:
-                # Base exception routers should pick this up and show bug page.
-                logger.error("QueryError: %s", ex)
-                raise InternalServerError(
+                raise BadRequest(
                     "There was a problem executing your query. Please try "
-                    "your search again.  If this problem persists, please "
+                    "a different query. If this problem persists, please "
                     "report it to help@arxiv.org."
                 ) from ex
             except index.OutsideAllowedRange as ex:

--- a/search/controllers/advanced/tests.py
+++ b/search/controllers/advanced/tests.py
@@ -177,7 +177,7 @@ class TestSearchController(TestCase):
                 "terms-0-term": "foo",
             }
         )
-        with self.assertRaises(InternalServerError):
+        with self.assertRaises(BadRequest):
             try:
                 response_data, code, headers = advanced.search(request_data)
             except QueryError as ex:

--- a/search/controllers/simple/__init__.py
+++ b/search/controllers/simple/__init__.py
@@ -158,11 +158,9 @@ def search(
                 "help@arxiv.org."
             ) from ex
         except index.QueryError as ex:
-            # Base exception routers should pick this up and show bug page.
-            logger.error("QueryError: %s", ex)
-            raise InternalServerError(
-                "There was a problem executing your query. Please try your "
-                "search again.  If this problem persists, please report it to "
+            raise BadRequest(
+                "There was a problem executing your query. Please try a different query. "
+                "If this problem persists, please report it to "
                 "help@arxiv.org."
             ) from ex
         except index.OutsideAllowedRange as ex:
@@ -232,11 +230,9 @@ def retrieve_document(document_id: str) -> Response:
             "help@arxiv.org."
         ) from ex
     except index.QueryError as ex:
-        # Base exception routers should pick this up and show bug page.
-        logger.error("QueryError: %s", ex)
-        raise InternalServerError(
-            "There was a problem executing your query. Please try your "
-            "search again.  If this problem persists, please report it to "
+        raise BadRequest(
+            "There was a problem executing your query. Please try a "
+            "different query. If this problem persists, please report it to "
             "help@arxiv.org."
         ) from ex
     except index.DocumentNotFound as ex:

--- a/search/controllers/simple/tests.py
+++ b/search/controllers/simple/tests.py
@@ -28,7 +28,7 @@ class TestRetrieveDocument(TestCase):
 
         mock_index.get_document.side_effect = _raiseQueryError
 
-        with self.assertRaises(InternalServerError):
+        with self.assertRaises(BadRequest):
             try:
                 response_data, code, headers = simple.retrieve_document(1)
             except QueryError as ex:
@@ -180,7 +180,7 @@ class TestSearchController(TestCase):
         mock_index.search.side_effect = _raiseQueryError
 
         request_data = MultiDict({"searchtype": "title", "query": "foo title"})
-        with self.assertRaises(InternalServerError):
+        with self.assertRaises(BadRequest):
             try:
                 response_data, code, headers = simple.search(request_data)
             except QueryError as ex:

--- a/search/services/index/__init__.py
+++ b/search/services/index/__init__.py
@@ -124,6 +124,9 @@ def handle_es_exceptions() -> Generator:
         elif ex.error == "parsing_exception":
             logger.error("ES parsing_exception: %s", ex.info)
             raise QueryError(ex.info) from ex
+        elif ex.error == "search_phase_execution_exception":
+            logger.error("ES execution_exception: %s", ex.info)
+            raise QueryError(ex.info) from ex
         elif ex.status_code == 404:
             logger.error("Caught NotFoundError: %s", ex)
             raise DocumentNotFound("No such document")
@@ -502,8 +505,6 @@ class SearchSession(metaclass=MetaIntegration):
                 current_search = classic_search(current_search, query)
         except TypeError as ex:
             raise ex
-            # logger.error('Malformed query: %s', str(e))
-            # raise QueryError('Malformed query') from e
 
         if highlight:
             # Highlighting is performed by Elasticsearch; here we include the

--- a/search/services/index/exceptions.py
+++ b/search/services/index/exceptions.py
@@ -27,7 +27,7 @@ class QueryError(ValueError):
     Elasticsearch could not handle the query.
 
     This is likely due either to a programming error that resulted in a bad
-    index, or to a mal-formed query.
+    index, or to a malformed query.
     """
 
 

--- a/search/templates/search/base.html
+++ b/search/templates/search/base.html
@@ -32,46 +32,6 @@
       }
     };
     </script>
-
-    <!-- Pendo -->
-    <script>
-     (function(apiKey){
-         (function(p,e,n,d,o){var v,w,x,y,z;o=p[d]=p[d]||{};o._q=[];
-             v=['initialize','identify','updateOptions','pageLoad'];for(w=0,x=v.length;w<x;++w)(function(m){
-                 o[m]=o[m]||function(){o._q[m===v[0]?'unshift':'push']([m].concat([].slice.call(arguments,0)));};})(v[w]);
-             y=e.createElement(n);y.async=!0;y.src='https://content.analytics.arxiv.org/agent/static/'+apiKey+'/pendo.js';
-             z=e.getElementsByTagName(n)[0];z.parentNode.insertBefore(y,z);})(window,document,'script','pendo');
-
-         // Call this whenever information about your visitors becomes available
-         // Please use Strings, Numbers, or Bools for value types.
-         pendo.initialize({
-             visitor: {
-                 id:              'VISITOR-UNIQUE-ID'   // Required if user is logged in
-                 // email:        // Recommended if using Pendo Feedback, or NPS Email
-                 // full_name:    // Recommended if using Pendo Feedback
-                 // role:         // Optional
-
-                 // You can add any additional visitor level key-values here,
-                 // as long as it's not one of the above reserved names.
-             },
-
-             account: {
-                 id:           'ACCOUNT-UNIQUE-ID' // Highly recommended
-                 // name:         // Optional
-                 // is_paying:    // Recommended if using Pendo Feedback
-                 // monthly_value:// Recommended if using Pendo Feedback
-                 // planLevel:    // Optional
-                 // planPrice:    // Optional
-                 // creationDate: // Optional
-
-                 // You can add any additional account level key-values here,
-                 // as long as it's not one of the above reserved names.
-             }
-         });
-     })('d6494389-b427-4103-7c76-03182ecc8e60');
-    </script>
-    <!-- End Pendo -->
-
 {% endblock addl_head %}
 
 {% block content %}

--- a/search/tests/test_searches.py
+++ b/search/tests/test_searches.py
@@ -1,0 +1,31 @@
+from http import HTTPStatus
+from unittest import TestCase
+
+from arxiv import taxonomy
+from search.factory import create_ui_web_app
+
+
+class TestSearchs(TestCase):
+    """Test for the advanced search UI."""
+
+    def setUp(self):
+        """Instantiate the UI application."""
+        self.app = create_ui_web_app()
+        self.client = self.app.test_client()
+
+    #@mock.patch("search.controllers.simple.SearchSession")
+    def test_bad_query(self):
+        """Bad query should result in a 400 not a 500. query from ARXIVNG-2437"""
+        response = self.client.get("/?query=%2F%3F&searchtype=all&source=header")
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.BAD_REQUEST,
+            "A query that cannot be parsed by ES should result in 400. ARXIVNG-2437",
+            )
+
+        response = self.client.get("/?query=+O%5E*%282.619%5Ek%29+algorithm+for+4-path+vertex+cover&searchtype=all&source=header")
+        self.assertEqual(
+            response.status_code,
+            HTTPStatus.BAD_REQUEST,
+            "A query that cannot be parsed by ES should result in 400. ARXIVNG-3971"
+            )

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -58,6 +58,6 @@ class TestExceptionHandling(TestCase):
         mock_search.side_effect = QueryError
         response = self.client.get("/?searchtype=title&query=foo")
         self.assertEqual(
-            response.status_code, HTTPStatus.INTERNAL_SERVER_ERROR
+            response.status_code, HTTPStatus.BAD_REQUEST
         )
         self.assertIn("text/html", response.content_type)


### PR DESCRIPTION
The status code for when ElasticSearch cannot parse or run a query was a 500. It is now a 400.

This is to distinguish between cases where the client is sending queries that cannot be run from cases where the app is having an unexpected internal error. Having this is intended to assist in our current effort reduce 500 errors in the system.

ARXIVNG-5111