### PR TITLE
Removes jira feedback collector link from search

### DIFF
--- a/search/templates/search/base.html
+++ b/search/templates/search/base.html
@@ -14,24 +14,6 @@
     display: none;
   }
   </style>
-  <script type="text/javascript" src="https://arxiv-org.atlassian.net/s/d41d8cd98f00b204e9800998ecf8427e-T/-tqqyqk/b/20/a44af77267a987a660377e5c46e0fb64/_/download/batch/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector/com.atlassian.jira.collector.plugin.jira-issue-collector-plugin:issuecollector.js?locale=en-US&collectorId=3b3dcb4c"></script>
-
-    <script type="text/javascript">
-    window.ATL_JQ_PAGE_PROPS =  {
-    	"triggerFunction": function(showCollectorDialog) {
-    		//Requires that jQuery is available!
-    		$("#feedback-button").click(function(e) {
-    			e.preventDefault();
-    			showCollectorDialog();
-    		});
-    	},
-      fieldValues: {
-        "components": ["16000"],  // Search component.
-        "versions": ["14260"],  // Release search-0.5.6
-        "customfield_11401": window.location.href
-      }
-    };
-    </script>
 {% endblock addl_head %}
 
 {% block content %}
@@ -52,7 +34,6 @@
       <div class="is-hidden-tablet">
         <!-- feedback for mobile only -->
         <span class="help" style="display: inline-block;"><a href="{{ config.RELEASE_NOTES_URL }}">{{ config.RELEASE_NOTES_TEXT }}</a>&nbsp;&nbsp;</span>
-        <button class="button is-small" id="feedback-button">Feedback?</button>
       </div>
     </div>
 {% endblock content %}


### PR DESCRIPTION
Very small commit to remove the jira feedback collector link from base.html in search.

It seems likely to be an oversight that the link is still there after all the other collector links were removed.  The reason for removal of those links was the low number of actionable tickets coming in (plus a lot of spam) vs. the high burden of parsing tickets and responding to users. That seems to be holding true for the search collector form also. We mostly get feedback around author name searches not working right, and they are quite correct, but it is a known issue that we cannot take action on at this time.

On a related note, we are working towards a plan for continuous, higher quality, qualitative feedback. Feedback is important, but we want it to be actionable on some level, and not leave users feeling unheard or waste their time.