### PR TITLE
removes non-functional Feedback? button

### DIFF
--- a/search/templates/search/base.html
+++ b/search/templates/search/base.html
@@ -24,7 +24,6 @@
     <div class="level-right is-hidden-mobile">
       <!-- feedback for mobile is moved to footer -->
       <span class="help" style="display: inline-block;"><a href="{{ config.RELEASE_NOTES_URL }}">{{ config.RELEASE_NOTES_TEXT }}</a>&nbsp;&nbsp;</span>
-      <button class="button is-small" id="feedback-button">Feedback?</button>
     </div>
   </div>
     <div class="content">


### PR DESCRIPTION
There have been several users reporting that the "feedback?" button on the advanced search page is non-functional. This PR removes that button.