### PR TITLE
ARXIVCE-4340: Accessibility remediations for search templates

### DIFF
--- a/search/static/css/search.css
+++ b/search/static/css/search.css
@@ -188,4 +188,14 @@
   }
 }
 
+button.link-style {
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  font-size: inherit;
+  font-family: inherit;
+  padding: 0;
+}
+
 /*# sourceMappingURL=search.css.map */

--- a/search/static/js/fieldset.js
+++ b/search/static/js/fieldset.js
@@ -45,6 +45,13 @@ $(function() {
               }
           });
 
+          // Update label for attributes to match new input IDs.
+          new_item.find("label[for]").each(function() {
+              var label_for = $(this).attr('for')
+                .replace('-' + (elem_num - 1) + '-', '-' + (elem_num) + '-');
+              $(this).attr('for', label_for);
+          });
+
           // Clear help text.
           new_item.find(".help").each(function() {
               $(this).empty();

--- a/search/templates/search/advanced_search.html
+++ b/search/templates/search/advanced_search.html
@@ -25,12 +25,12 @@
 <div class="columns is-desktop">
   <div class="column is-one-half-desktop">
     {% if form.errors %}
-    <div class="notification is-warning">
+    <div class="notification is-warning" role="alert">
       Whoops! Something went wrong. Please correct errors in the form below.
     </div>
     {% endif %}
     <div class="box">
-      <form method="GET" action="{{ url_for('ui.advanced_search') }}">
+      <form method="GET" action="{{ url_for('ui.advanced_search') }}" role="search">
         {{ form.advanced|safe }}
         {# Field-specific search term fieldset. #}
         <section data-toggle="fieldset" id="terms-fieldset">
@@ -324,6 +324,7 @@
 
 
 {% block title %}
+    <span role="status">
     {% if not show_form and results %}
         Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total_results) }} results
     {% elif show_form %}
@@ -331,6 +332,7 @@
     {% else %}
         Sorry, your query returned no results
     {% endif %}
+    </span>
 {% endblock title %}
 
 {% block within_content %}

--- a/search/templates/search/search-macros.html
+++ b/search/templates/search/search-macros.html
@@ -43,8 +43,8 @@
     </a>
     {% endif %}
     {% if metadata.current_page < metadata.total_pages %}
-      <a href="{% if metadata.current_page + 1 <= metadata.max_pages %}{{ url_for_page(metadata.current_page + 1, metadata.size) }}{% endif %}"
-        class="pagination-next" {% if metadata.current_page + 1 > metadata.max_pages %}disabled="true"{% endif %}>Next
+      <a {% if metadata.current_page + 1 <= metadata.max_pages %}href="{{ url_for_page(metadata.current_page + 1, metadata.size) }}"{% else %}aria-disabled="true" tabindex="-1"{% endif %}
+        class="pagination-next">Next
       </a>
     {% else %}
     <a href=""
@@ -56,7 +56,8 @@
       <li>
         <a href="{{ url_for_page(1, metadata.size) }}"
           class="pagination-link {% if metadata.current_page == 1 %}is-current{% endif %}"
-          aria-label="Goto page 1">1
+          aria-label="Page 1"
+          {% if metadata.current_page == 1 %}aria-current="page"{% endif %}>1
         </a>
       </li>
 
@@ -66,7 +67,7 @@
           <a href="{{ url_for_page(p, metadata.size) }}"
             class="pagination-link {% if metadata.current_page == p %}is-current{% endif %}"
             aria-label="Page {{ p }}"
-            aria-current="page">{{ p }}
+            {% if metadata.current_page == p %}aria-current="page"{% endif %}>{{ p }}
           </a>
         </li>
         {% endfor %}
@@ -77,7 +78,7 @@
             <a href="{{ url_for_page(p, metadata.size) }}"
               class="pagination-link {% if metadata.current_page == p %}is-current{% endif %}"
               aria-label="Page {{ p }}"
-              aria-current="page">{{ p }}
+              {% if metadata.current_page == p %}aria-current="page"{% endif %}>{{ p }}
             </a>
           </li>
           {% endfor %}
@@ -89,7 +90,7 @@
             <a href="{{ url_for_page(p, metadata.size) }}"
               class="pagination-link {% if metadata.current_page == p %}is-current{% endif %}"
               aria-label="Page {{ p }}"
-              aria-current="page">{{ p }}
+              {% if metadata.current_page == p %}aria-current="page"{% endif %}>{{ p }}
             </a>
           </li>
           {% endfor %}
@@ -101,7 +102,7 @@
             <a href="{{ url_for_page(p, metadata.size) }}"
               class="pagination-link {% if metadata.current_page == p %}is-current{% endif %}"
               aria-label="Page {{ p }}"
-              aria-current="page">{{ p }}
+              {% if metadata.current_page == p %}aria-current="page"{% endif %}>{{ p }}
             </a>
           </li>
           {% endif %}
@@ -137,10 +138,10 @@
         <span>&nbsp;{{ paper_format_links(result, display_paper_id) }}&nbsp;</span>
       </p>
       <div class="tags is-inline-block">
-        <span class="tag is-small {% if result.match.primary_classification %}search-hit{% else %}is-link{% endif %} tooltip is-tooltip-top" data-tooltip="{{ result.primary_classification|category_name }}">{{ result.primary_classification.category.id }}</span>
+        <span class="tag is-small {% if result.match.primary_classification %}search-hit{% else %}is-link{% endif %} tooltip is-tooltip-top" data-tooltip="{{ result.primary_classification|category_name }}" aria-label="{{ result.primary_classification|category_name }} ({{ result.primary_classification.category.id }})" role="text">{{ result.primary_classification.category.id }}</span>
         {% if result.secondary_classification %}
           {% for secondary in result.secondary_classification %}
-            <span class="tag is-small {% if secondary.category.id in result.match.secondary_classification %}search-hit{% else %}is-grey{% endif %} tooltip is-tooltip-top" data-tooltip="{{secondary|category_name}}">{{ secondary.category.id }}</span>
+            <span class="tag is-small {% if secondary.category.id in result.match.secondary_classification %}search-hit{% else %}is-grey{% endif %} tooltip is-tooltip-top" data-tooltip="{{secondary|category_name}}" aria-label="{{ secondary|category_name }} ({{ secondary.category.id }})" role="text">{{ secondary.category.id }}</span>
           {% endfor %}
         {% endif -%}
       </div>
@@ -175,11 +176,11 @@
       <span class="{% if result.match.abstract %}search-hit{% else %}has-text-black-bis has-text-weight-semibold{% endif %}">Abstract</span>:
       <span class="abstract-short has-text-grey-dark mathjax" id="{{result.id}}-abstract-short" style="display: inline;">
         {{ result.preview.abstract | safe }}
-        {%if result.truncated.abstract %}<a class="is-size-7" style="white-space: nowrap;" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'inline'; document.getElementById('{{result.id}}-abstract-short').style.display = 'none';">&#9661; More</a>{% endif %}
+        {%if result.truncated.abstract %}<button type="button" class="is-size-7 link-style" style="white-space: nowrap;" aria-expanded="false" aria-label="Show full abstract" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'inline'; document.getElementById('{{result.id}}-abstract-short').style.display = 'none';">&#9661; More</button>{% endif %}
       </span>
       <span class="abstract-full has-text-grey-dark mathjax" id="{{result.id}}-abstract-full" style="display: none;">
         {% if result.highlight.abstract %}{{ result.highlight.abstract | safe }}{% else %}{{ result.abstract }}{% endif %}
-        <a class="is-size-7" style="white-space: nowrap;" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'none'; document.getElementById('{{result.id}}-abstract-short').style.display = 'inline';">&#9651; Less</a>
+        <button type="button" class="is-size-7 link-style" style="white-space: nowrap;" aria-expanded="true" aria-label="Hide full abstract" onclick="document.getElementById('{{result.id}}-abstract-full').style.display = 'none'; document.getElementById('{{result.id}}-abstract-short').style.display = 'inline';">&#9651; Less</button>
       </span>
     </p>
     {% endif %}

--- a/search/templates/search/search.html
+++ b/search/templates/search/search.html
@@ -3,15 +3,17 @@
 {% import "search/search-macros.html" as search_macros %}
 
 {% block title %}
+    <span role="status">
     {% if results %}
         Showing {{ metadata.start + 1 }}&ndash;{{ metadata.end }} of {{ '{0:,}'.format(metadata.total_results) }} results for {{ query.search_field }}: <span class="mathjax">{{ query.value }}</span>
     {% else %}
         Search
     {% endif %}
+    </span>
 {% endblock title %}
 
 {% block within_content %}
-  <form method="GET" action="{{ url_for('ui.search', archives=archives) }}" {% if not query and not results %} class="breathe-vertical" {% endif %} aria-role="search">
+  <form method="GET" action="{{ url_for('ui.search', archives=archives) }}" {% if not query and not results %} class="breathe-vertical" {% endif %} role="search">
     {% if archives %}
       Searching in archive{% if archives|length > 1 %}s{% endif %} <strong>{{ archives|join(", ") }}</strong>. <a href="{{ url_for('ui.search') }}?{{ current_url_params() }}">Search in all archives.</a>
     {% endif %}


### PR DESCRIPTION
## Summary
- Fix invalid `aria-role` attribute to `role="search"` on simple search form
- Add `role="search"` to advanced search form
- Convert abstract expand/collapse from inaccessible `<a onclick>` to keyboard-accessible `<button>` elements with `aria-expanded` state
- Fix `aria-current="page"` to only apply to the actual current page in pagination
- Fix invalid `disabled` attribute on pagination "Next" link (use `aria-disabled` + `tabindex="-1"`)
- Add `aria-label` to category tag tooltips so screen readers announce full category names
- Update fieldset.js to maintain `<label for>` associations when cloning search term rows
- Add `role="status"` live regions so screen readers announce results count
- Add `role="alert"` to form validation error notifications

## WCAG criteria addressed
- 1.3.1 Info and Relationships (A)
- 2.1.1 Keyboard (A)
- 3.3.1 Error Identification (A)
- 4.1.2 Name, Role, Value (A)
- 4.1.3 Status Messages (AA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)